### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on: 
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/iocrafts/hsftp/security/code-scanning/2](https://github.com/iocrafts/hsftp/security/code-scanning/2)

To fix the problem, add an explicit `permissions:` block to the workflow (in `.github/workflows/release.yml`). The safest recommendation is to add it just below the `name:` field, so that it will apply to all jobs in the workflow. For most Docker build/push jobs, only read access to repository contents is needed, unless code is being committed, releases are being published, or other actions require write access. Since this workflow does not appear to require write access, set the workflow-wide permission to `contents: read` for least privilege. If the reused build.yml workflow requires additional permissions, those should be set there, not here.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
